### PR TITLE
fix: Migrate from IBus to fcitx5-mozc to fix GTK4 double input bug

### DIFF
--- a/docs/pr-review/9_61213e22f7af49c0c8c289415e0fb10503f11cdf_claude.md
+++ b/docs/pr-review/9_61213e22f7af49c0c8c289415e0fb10503f11cdf_claude.md
@@ -1,0 +1,74 @@
+## PR #9 レビュー: IBusからfcitx5-mozcへの移行
+
+### 変更の概要
+
+Ubuntu 24.04のIBus + GTK4における二重入力バグを回避するため、入力メソッドフレームワークをIBusからfcitx5-mozcに移行する変更です。
+
+**変更ファイル:**
+- `install.sh` - fcitx5セットアップスクリプトの呼び出しを追加
+- `scripts/install_apt.sh` - fcitx5関連パッケージの追加
+- `scripts/gsettings.sh` - IBus絵文字ホットキー設定の削除
+- `scripts/settings_fcitx5.sh` - 新規: fcitx5をデフォルトIMに設定するスクリプト
+- `scripts/migration/migrate_to_fcitx5.sh` - 新規: 既存環境向けの移行スクリプト
+
+---
+
+### 詳細な指摘事項
+
+#### Warning
+
+**1. 環境変数の設定が不足している可能性**
+
+fcitx5を正しく動作させるには、通常以下の環境変数が必要です:
+
+```
+GTK_IM_MODULE=fcitx
+QT_IM_MODULE=fcitx
+XMODIFIERS=@im=fcitx
+```
+
+`im-config -n fcitx5` はこれらの環境変数を `/etc/X11/xinit/xinputrc` 経由で自動設定しますが、Wayland環境や一部のデスクトップ環境では反映されない場合があります。`.zshenv` や `.profile` にこれらの環境変数が設定されていないため、特にWayland（Ubuntu 24.04のデフォルト）での動作が不安定になる可能性があります。
+
+ただし、Ubuntu 24.04ではfcitx5がim-config経由で適切に設定されれば、GNOMEのWaylandセッションでも問題なく動作するケースが多いです。もしWaylandで問題が出た場合は、環境変数の明示的な設定を検討してください。
+
+**対象ファイル:** `scripts/settings_fcitx5.sh`
+
+**2. マイグレーションスクリプトにエラーハンドリングがない**
+
+`scripts/migration/migrate_to_fcitx5.sh` では `sudo apt install` と `sudo apt remove` を実行していますが、途中のコマンドが失敗しても処理が続行されます。例えば、`apt install` が失敗した状態で `apt remove -y ibus-mozc` が実行されると、入力メソッドが使えない状態になる可能性があります。
+
+`set -e` を追加するか、各コマンドの後にエラーチェックを入れることを推奨します。
+
+**対象ファイル:** `scripts/migration/migrate_to_fcitx5.sh`
+
+**3. settings_fcitx5.sh の `pushd`/`popd` が不要**
+
+`settings_fcitx5.sh` では `pushd $PWD` / `cd \`dirname $0\`` のパターンが使われていますが、スクリプト内でカレントディレクトリに依存する処理（ファイル読み込みや相対パスでのスクリプト実行など）が一切ありません。`im-config -n fcitx5` は絶対パスで動作するため、この `pushd`/`popd` は不要です。
+
+ただし、これはリポジトリ内の他のスクリプト（`settings_podman.sh` や `gsettings.sh`）と同じパターンに従っているため、一貫性を優先してこのままにするという判断も理解できます。
+
+**対象ファイル:** `scripts/settings_fcitx5.sh`
+
+#### Info
+
+**4. ibus-mozcのアンインストールがinstall.shのフローに含まれていない**
+
+`scripts/migration/migrate_to_fcitx5.sh` では `sudo apt remove -y ibus-mozc` を実行していますが、通常のインストールフロー（`install.sh` -> `settings_fcitx5.sh`）にはibus-mozcの削除が含まれていません。新規セットアップの場合は問題ありませんが、既存のIBus環境からの移行で `install.sh` を再実行した場合、ibus-mozcが残存してfcitx5と競合する可能性があります。
+
+マイグレーションスクリプトが別途用意されているので意図的な設計と思われますが、コメントで明記しておくとよいかもしれません。
+
+**5. パッケージリストの重複管理**
+
+fcitx5関連のパッケージリストが `install_apt.sh` と `migrate_to_fcitx5.sh` の2箇所に同じ内容で記載されています。将来パッケージを追加・変更する際に片方だけ更新する可能性があります。軽微な問題ですが、認識しておくと良いでしょう。
+
+**6. gsettingsからのIBus設定削除は適切**
+
+IBus絵文字ホットキーの設定（`gsettings set org.freedesktop.ibus.panel.emoji hotkey`）の削除は、IBusからの移行に伴う適切なクリーンアップです。
+
+---
+
+### Verdict: **APPROVE**
+
+変更は全体として適切で、GTK4の二重入力バグに対する妥当な解決策です。新規セットアップ向けの `settings_fcitx5.sh` では `im-config` と `fcitx5` の存在チェックが行われており、防御的に実装されています。マイグレーションスクリプトも別途用意されており、既存環境への配慮もなされています。
+
+Warningとして挙げた環境変数の件とエラーハンドリングの件は、改善が望ましいものの、現状でも `im-config` の自動設定に依存する形で動作する可能性が高く、ブロッカーではありません。今後Waylandで問題が発生した場合にフォローアップとして対応すればよいでしょう。

--- a/docs/pr-review/9_61213e22f7af49c0c8c289415e0fb10503f11cdf_codex.md
+++ b/docs/pr-review/9_61213e22f7af49c0c8c289415e0fb10503f11cdf_codex.md
@@ -1,0 +1,12 @@
+## PR #9 Codexレビュー: IBusからfcitx5-mozcへの移行
+
+1. 中: 既存環境は通常フローでは移行されません。[install.sh](/home/gladevise/dotfiles/install.sh) の 11-14 行目は `fcitx5` を入れて `im-config -n fcitx5` を叩くだけで、`ibus-mozc` を外す処理は [scripts/migration/migrate_to_fcitx5.sh](/home/gladevise/dotfiles/scripts/migration/migrate_to_fcitx5.sh) の 10-17 行目にしかありません。さらに [scripts/upgrade.sh](/home/gladevise/dotfiles/scripts/upgrade.sh) の 7-19 行目からもこの移行スクリプトは呼ばれていないので、既存の 24.04 環境で `upg` や `./install.sh` を回すだけだと、今回直したい GTK4 の二重入力が残る経路がそのまま残ります。
+
+2. 低: 絵文字ピッカーのショートカットが無関係に消えます。[scripts/gsettings.sh](/home/gladevise/dotfiles/scripts/gsettings.sh) から `org.freedesktop.ibus.panel.emoji hotkey` の設定を削除していますが、この PR 自体は IBus 本体を残す方針です。つまりこの削除は fcitx5 移行の成立条件ではなく、fresh install で既存の絵文字ショートカットだけを失う回帰になります。
+
+補足すると、ローカル実行環境の制約で実機検証はしていません。レビューは PR 差分と現行スクリプトの読み合わせベースです。
+
+Sources:
+- https://github.com/gladevise/dotfiles/pull/9/files
+- https://github.com/gladevise/dotfiles/blob/main/scripts/upgrade.sh
+- https://github.com/gladevise/dotfiles/blob/fix/migrate-ibus-to-fcitx5/scripts/migration/migrate_to_fcitx5.sh

--- a/docs/pr-review/9_edb0f9f70a576b222073851bba27ddb8766a8b29_claude.md
+++ b/docs/pr-review/9_edb0f9f70a576b222073851bba27ddb8766a8b29_claude.md
@@ -1,0 +1,27 @@
+# Claude Code Review - PR #9
+
+## PR
+fix: Migrate from IBus to fcitx5-mozc to fix GTK4 double input bug
+
+## Verdict: APPROVE
+
+## Review Summary
+
+No issues found. Checked for bugs and CLAUDE.md compliance.
+
+### Review Details
+
+**4 parallel review agents were launched:**
+
+1. **CLAUDE.md Compliance Agent 1** (files: install.sh, scripts/install_apt.sh, scripts/gsettings.sh, scripts/settings_fcitx5.sh): No CLAUDE.md compliance issues found. The CLAUDE.md rule ("Think in English, generate responses in Japanese") governs Claude's conversational behavior only — it places no constraints on code content, comments, or script output messages.
+
+2. **CLAUDE.md Compliance Agent 2** (files: scripts/migration/migrate_to_fcitx5.sh, settings/.config/fcitx5/config, settings/.config/fcitx5/profile): No CLAUDE.md compliance issues found.
+
+3. **Bug Review Agent 1 (diff-only scan)**: No bugs found. The diff is clean — scripts have proper error checking, correct quoting, logical ordering of operations, and static configuration files are well-formed fcitx5 INI format.
+
+4. **Bug Review Agent 2 (deep analysis)**: No issues found. Considered and dismissed several potential concerns:
+   - `settings_fcitx5.sh` lacks `set -euo pipefail` — matches existing codebase pattern
+   - `pushd $PWD` / unquoted variables — matches pre-existing pattern in repo
+   - `settings_fcitx5.sh` called before `link.sh` — ordering is correct since fcitx5 reads config at runtime
+   - `migrate_to_fcitx5.sh` calls `$SCRIPT_DIR/../link.sh` — resolves correctly
+   - `DefaultIM=keyboard-us` with mozc as Items/0 — standard fcitx5 configuration

--- a/docs/pr-review/9_edb0f9f70a576b222073851bba27ddb8766a8b29_codex.md
+++ b/docs/pr-review/9_edb0f9f70a576b222073851bba27ddb8766a8b29_codex.md
@@ -1,0 +1,27 @@
+# Codex Code Review - PR #9
+
+## PR
+fix: Migrate from IBus to fcitx5-mozc to fix GTK4 double input bug
+
+## Verdict: REQUEST_CHANGES
+
+## Issues Found
+
+### 1. Mozc が fcitx5 の入力メソッド一覧に自動登録されない可能性
+
+`im-config -n fcitx5` だけでは Mozc は `fcitx5` の入力メソッド一覧に追加されないため、移行後に日本語入力できなくなる可能性があります。`install.sh` から呼ばれる `scripts/settings_fcitx5.sh` も、手動移行用の `scripts/migration/migrate_to_fcitx5.sh` も「フレームワークを fcitx5 に切り替える」だけで、Mozc を profile に登録していません。しかも移行スクリプトは `ibus-mozc` を削除しているので、既存環境では再起動後に日本語 IM が空になり、手動で `Mozc` を追加するまで入力不能になりえます。今回の目的が「GTK4 の二重入力を直しつつ、従来どおり日本語入力を使える状態に保つ」ことなら、profile の投入まで自動化しないと不完全です。
+
+### 2. 移行スクリプトが標準導線から到達不可
+
+この PR の修正は標準の導線では既存環境に適用されません。通常のエントリポイントは `install.sh` ですが、ここで実行しているのは `scripts/settings_fcitx5.sh` だけで、`scripts/migration/migrate_to_fcitx5.sh` はどこからも呼ばれていません。つまり、すでに `ibus-mozc` で運用していて GTK4 二重入力バグに当たっているマシンは、いつもの `./install.sh` を流し直しても直らず、手動で移行スクリプトを見つけて叩いた場合にしか修正が入らない状態です。PR タイトルどおりの「fix」にするなら、少なくとも標準導線から到達できるようにするか、既存環境向けの移行を明示的に組み込む必要があります。
+
+## 前提
+
+`fcitx5-mozc` が Ubuntu 24.04 GNOME 上で profile を自動生成しない前提で見ています。一般的な `fcitx5` の挙動と公開情報ではその理解で問題なさそうですが、もし手元で自動追加を確認済みなら 1 件目は取り下げ可能です。
+
+## 参照
+
+- [PR #9](https://github.com/gladevise/dotfiles/pull/9)
+- [install.sh on PR branch](https://github.com/gladevise/dotfiles/blob/fix/migrate-ibus-to-fcitx5/install.sh)
+- [scripts/settings_fcitx5.sh on PR branch](https://github.com/gladevise/dotfiles/blob/fix/migrate-ibus-to-fcitx5/scripts/settings_fcitx5.sh)
+- [scripts/migration/migrate_to_fcitx5.sh on PR branch](https://github.com/gladevise/dotfiles/blob/fix/migrate-ibus-to-fcitx5/scripts/migration/migrate_to_fcitx5.sh)

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,9 @@ echo $PWD
 # Install apt packages
 ./scripts/install_apt.sh
 
+# Setup fcitx5 input method
+./scripts/settings_fcitx5.sh
+
 # Settings for podman
 ./scripts/settings_podman.sh
 

--- a/scripts/gsettings.sh
+++ b/scripts/gsettings.sh
@@ -4,8 +4,6 @@ pushd $PWD
 cd `dirname $0`
 echo $PWD
 
-gsettings set org.freedesktop.ibus.panel.emoji hotkey "['<Super>period']"
-
 # set nautilus default sort order
 gsettings set org.gnome.nautilus.preferences default-sort-order 'mtime'
 gsettings set org.gnome.nautilus.preferences default-sort-in-reverse-order 'true'

--- a/scripts/install_apt.sh
+++ b/scripts/install_apt.sh
@@ -80,6 +80,13 @@ packages=(
   fcitx5-config-qt
   fcitx5-frontend-all
 
+  # Japanese Language Support
+  language-pack-ja
+  language-pack-ja-base
+  language-pack-gnome-ja
+  language-pack-gnome-ja-base
+  fonts-noto-cjk
+
   # Containers
   podman
 )

--- a/scripts/install_apt.sh
+++ b/scripts/install_apt.sh
@@ -73,6 +73,13 @@ packages=(
   gnome-tweaks
   gnome-shell-extensions
 
+  # Input Method
+  im-config
+  fcitx5
+  fcitx5-mozc
+  fcitx5-config-qt
+  fcitx5-frontend-all
+
   # Containers
   podman
 )

--- a/scripts/migration/migrate_to_fcitx5.sh
+++ b/scripts/migration/migrate_to_fcitx5.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# IBus+Mozc環境からfcitx5+Mozcへの移行
+# Ubuntu 24.04のIBus二重入力バグの回避策
+
+echo "=== Migrating from IBus to fcitx5-mozc ==="
+
+# Install fcitx5 packages
+sudo apt install -y im-config fcitx5 fcitx5-mozc fcitx5-config-qt fcitx5-frontend-all
+
+# Set fcitx5 as default input method
+im-config -n fcitx5
+
+# Remove ibus-mozc (keep ibus itself as GNOME dependency)
+sudo apt remove -y ibus-mozc
+
+echo ""
+echo "Migration complete. Please reboot your system."
+echo "After reboot:"
+echo "  1. Run 'fcitx5-diagnose' to verify the setup"
+echo "  2. Open 'Fcitx5 Configuration' from application menu"
+echo "  3. Verify 'Mozc' is in the input method list"

--- a/scripts/migration/migrate_to_fcitx5.sh
+++ b/scripts/migration/migrate_to_fcitx5.sh
@@ -1,21 +1,40 @@
 #!/bin/bash
+set -euo pipefail
+
 # IBus+Mozc環境からfcitx5+Mozcへの移行
 # Ubuntu 24.04のIBus二重入力バグの回避策
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 echo "=== Migrating from IBus to fcitx5-mozc ==="
 
 # Install fcitx5 packages
 sudo apt install -y im-config fcitx5 fcitx5-mozc fcitx5-config-qt fcitx5-frontend-all
 
+# Install Japanese language support
+sudo apt install -y language-pack-ja language-pack-ja-base \
+  language-pack-gnome-ja language-pack-gnome-ja-base fonts-noto-cjk
+
+# Generate Japanese locale
+if ! locale -a 2>/dev/null | grep -q 'ja_JP\.utf8'; then
+  echo "Generating ja_JP.UTF-8 locale..."
+  sudo locale-gen ja_JP.UTF-8
+fi
+
 # Set fcitx5 as default input method
 im-config -n fcitx5
 
 # Remove ibus-mozc (keep ibus itself as GNOME dependency)
-sudo apt remove -y ibus-mozc
+if dpkg -l ibus-mozc 2>/dev/null | grep -q '^ii'; then
+  sudo apt remove -y ibus-mozc
+else
+  echo "ibus-mozc is not installed, skipping removal."
+fi
+
+# Deploy fcitx5 configuration files via link.sh
+echo "Deploying fcitx5 configuration files..."
+bash "$SCRIPT_DIR/../link.sh"
 
 echo ""
 echo "Migration complete. Please reboot your system."
-echo "After reboot:"
-echo "  1. Run 'fcitx5-diagnose' to verify the setup"
-echo "  2. Open 'Fcitx5 Configuration' from application menu"
-echo "  3. Verify 'Mozc' is in the input method list"
+echo "After reboot, run 'fcitx5-diagnose' to verify the setup."

--- a/scripts/settings_fcitx5.sh
+++ b/scripts/settings_fcitx5.sh
@@ -7,9 +7,20 @@ cd `dirname $0`
 if command -v im-config &>/dev/null && command -v fcitx5 &>/dev/null; then
   im-config -n fcitx5
   echo "fcitx5 has been set as the default input method framework."
-  echo "Please reboot for the changes to take effect."
 else
-  echo "WARNING: fcitx5 or im-config is not installed. Run install_apt.sh first."
+  echo "ERROR: fcitx5 or im-config is not installed. Run install_apt.sh first."
+  exit 1
 fi
+
+# Generate Japanese locale
+if ! locale -a 2>/dev/null | grep -q 'ja_JP\.utf8'; then
+  echo "Generating ja_JP.UTF-8 locale..."
+  sudo locale-gen ja_JP.UTF-8
+  echo "ja_JP.UTF-8 locale generated."
+else
+  echo "ja_JP.UTF-8 locale is already available."
+fi
+
+echo "Please reboot for the changes to take effect."
 
 popd

--- a/scripts/settings_fcitx5.sh
+++ b/scripts/settings_fcitx5.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+pushd $PWD
+cd `dirname $0`
+
+# Set fcitx5 as the default input method framework
+if command -v im-config &>/dev/null && command -v fcitx5 &>/dev/null; then
+  im-config -n fcitx5
+  echo "fcitx5 has been set as the default input method framework."
+  echo "Please reboot for the changes to take effect."
+else
+  echo "WARNING: fcitx5 or im-config is not installed. Run install_apt.sh first."
+fi
+
+popd

--- a/settings/.config/fcitx5/config
+++ b/settings/.config/fcitx5/config
@@ -1,0 +1,76 @@
+[Hotkey]
+# Enumerate when press trigger key repeatedly
+EnumerateWithTriggerKeys=True
+# Enumerate Input Method Forward
+EnumerateForwardKeys=
+# Enumerate Input Method Backward
+EnumerateBackwardKeys=
+# Skip first input method while enumerating
+EnumerateSkipFirst=False
+# Enumerate Input Method Group Forward
+EnumerateGroupForwardKeys=
+# Enumerate Input Method Group Backward
+EnumerateGroupBackwardKeys=
+
+[Hotkey/TriggerKeys]
+0=Zenkaku_Hankaku
+1=Hangul
+2=Control+Shift+Tab
+
+[Hotkey/AltTriggerKeys]
+0=Shift_L
+
+[Hotkey/ActivateKeys]
+0=Hangul_Hanja
+
+[Hotkey/DeactivateKeys]
+0=Hangul_Romaja
+
+[Hotkey/PrevPage]
+0=Up
+
+[Hotkey/NextPage]
+0=Down
+
+[Hotkey/PrevCandidate]
+0=Shift+Tab
+
+[Hotkey/NextCandidate]
+0=Tab
+
+[Hotkey/TogglePreedit]
+0=Control+Alt+P
+
+[Behavior]
+# Active By Default
+ActiveByDefault=False
+# Share Input State
+ShareInputState=Program
+# Show preedit in application
+PreeditEnabledByDefault=True
+# Show Input Method Information when switch input method
+ShowInputMethodInformation=True
+# Show Input Method Information when changing focus
+showInputMethodInformationWhenFocusIn=False
+# Show compact input method information
+CompactInputMethodInformation=True
+# Show first input method information
+ShowFirstInputMethodInformation=True
+# Default page size
+DefaultPageSize=5
+# Override Xkb Option
+OverrideXkbOption=False
+# Custom Xkb Option
+CustomXkbOption=
+# Force Enabled Addons
+EnabledAddons=
+# Force Disabled Addons
+DisabledAddons=
+# Preload input method to be used by default
+PreloadInputMethod=True
+# Allow input method in the password field
+AllowInputMethodForPassword=False
+# Show preedit text when typing password
+ShowPreeditForPassword=False
+# Interval of saving user data in minutes
+AutoSavePeriod=30

--- a/settings/.config/fcitx5/profile
+++ b/settings/.config/fcitx5/profile
@@ -1,0 +1,22 @@
+[Groups/0]
+# Group Name
+Name=Default
+# Layout
+Default Layout=us
+# Default Input Method
+DefaultIM=keyboard-us
+
+[Groups/0/Items/0]
+# Name
+Name=mozc
+# Layout
+Layout=
+
+[Groups/0/Items/1]
+# Name
+Name=keyboard-us
+# Layout
+Layout=
+
+[GroupOrder]
+0=Default


### PR DESCRIPTION
## Summary

- Ubuntu 24.04のIBus + MozcでGTK4アプリ（GNOMEテキストエディタ、Nautilus等）において日本語入力が二重に表示されるバグを修正
- 入力メソッドフレームワークをIBusからfcitx5-mozcに切り替え
- 既存環境向けの移行スクリプト(`scripts/migration/migrate_to_fcitx5.sh`)を追加

## Changes

| ファイル | 変更内容 |
|---|---|
| `scripts/install_apt.sh` | fcitx5関連パッケージを追加 (`im-config`, `fcitx5`, `fcitx5-mozc`, `fcitx5-config-qt`, `fcitx5-frontend-all`) |
| `scripts/settings_fcitx5.sh` | 新規: `im-config -n fcitx5`でデフォルトIMを設定 |
| `scripts/gsettings.sh` | IBus emoji hotkey設定を削除 |
| `install.sh` | `settings_fcitx5.sh`の呼び出しを追加 |
| `scripts/migration/migrate_to_fcitx5.sh` | 新規: 既存環境向け移行スクリプト |

## Design decisions

- **環境変数は手動設定しない**: `im-config -n fcitx5`が自動設定。GTK4 + Waylandではinput method portalを使うため`GTK_IM_MODULE`を設定しない方が正しい
- **IBus本体は削除しない**: `gnome-shell`の依存関係のため`ibus-mozc`のみ削除
- **Mozcユーザー辞書は自動引き継ぎ**: `~/.config/mozc/`はIBus/fcitx5共通

## Test plan

- [ ] `scripts/migration/migrate_to_fcitx5.sh`を実行後、再起動
- [ ] `fcitx5-diagnose`で設定に問題がないことを確認
- [ ] GNOMEテキストエディタで日本語入力し二重入力が発生しないことを確認
- [ ] Nautilusのファイル名変更で日本語入力を確認
- [ ] ターミナル（Ghostty/Alacritty）で日本語入力を確認
- [ ] VS Codeで日本語入力を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)